### PR TITLE
Use 'input' event instead of 'keyup' on text inputs

### DIFF
--- a/lesson-plans/group-project-intro/examples/welcome/src/change-first.js
+++ b/lesson-plans/group-project-intro/examples/welcome/src/change-first.js
@@ -26,4 +26,4 @@ const changeFirst = () => {
 };
 
 // tell the browser to call your function each time the user interacts
-document.getElementById('first-name').addEventListener('keyup', changeFirst);
+document.getElementById('first-name').addEventListener('input', changeFirst);

--- a/lesson-plans/group-project-intro/examples/welcome/src/change-last.js
+++ b/lesson-plans/group-project-intro/examples/welcome/src/change-last.js
@@ -26,4 +26,4 @@ const changeLast = () => {
 };
 
 // tell the browser to call your function each time the user interacts
-document.getElementById('last-name').addEventListener('keyup', changeLast);
+document.getElementById('last-name').addEventListener('input', changeLast);


### PR DESCRIPTION
Keyup isn't triggered in some situations. For example pasting text with the mouse (right click, paste) will not trigger that keyup event. For form inputs, the 'input' event is the safest as it is triggered with any change.